### PR TITLE
Modify the seqplay to accept zmp and com/ankle derivatives

### DIFF
--- a/src/seqplay.cc
+++ b/src/seqplay.cc
@@ -1,7 +1,7 @@
 //
 // Copyright (C) 2012, 2013 LAAS-CNRS
 //
-// Author: Florent Lamiraux
+// Author: Florent Lamiraux, Mehdi Benallegue
 //
 
 #include <vector>

--- a/src/seqplay.hh
+++ b/src/seqplay.hh
@@ -1,7 +1,7 @@
 //
 // Copyright (C) 2012, 2013 LAAS-CNRS
 //
-// Author: Florent Lamiraux
+// Author: Florent Lamiraux, Mehdi Benallegue
 //
 
 #ifndef SOT_TOOLS_SEQPLAY_HH


### PR DESCRIPTION
The reference feet forces, zmp and derivatives are now optional
The derivatives are automatically computed using finite differences if the derivatives files are not available.
